### PR TITLE
Prepare to exist as an independent repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .mypy_cache
 *.egg-info
 *.pyc
+pip-wheel-metadata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM sdp-docker-registry.kat.ac.za:5000/docker-base-build as build
+ARG KATSDPDOCKERBASE_REGISTRY=quay.io/ska-sa
+
+FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-build as build
 
 # Enable Python 3 venv
 ENV PATH="$PATH_PYTHON3" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON3"
@@ -15,7 +17,8 @@ RUN cd /tmp/install/switch_exporter && \
 
 #######################################################################
 
-FROM sdp-docker-registry.kat.ac.za:5000/docker-base-runtime
+FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-runtime
+LABEL maintainer=sdpdev+switch_exporter@ska.ac.za
 
 COPY --chown=kat:kat --from=build /home/kat/ve3 /home/kat/ve3
 ENV PATH="$PATH_PYTHON3" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON3"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,7 @@
+#!groovy
+
+@Library('katsdpjenkins') _
+katsdp.killOldJobs()
+katsdp.setDependencies(['ska-sa/katsdpdockerbase/master'])
+katsdp.standardBuild(python3: true, python2: false, push_external: true)
+katsdp.mail('sdpdev+switch_exporter@ska.ac.za')

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2019, National Research Foundation (SARAO)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ from setuptools import setup, find_packages
 
 setup(
     name='switch_exporter',
-    author='Bruce Merry',
-    author_email='bmerry@ska.ac.za',
+    author='MeerKAT SDP team',
+    author_email='sdpdev+switch_exporter@ska.ac.za',
     description='Prometheus exporter for Mellanox switch counters',
     packages=find_packages(),
     setup_requires=['katversion'],


### PR DESCRIPTION
The changes are based on those done for netdev_exporter. It will need a
sdpdev+switch_exporter mail alias set up.