### PR TITLE
Bump minimum Python to 3.6

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
-python_version = 3.5
+python_version = 3.6
 ignore_missing_imports = True
 files = switch_exporter

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='Prometheus exporter for Mellanox switch counters',
     packages=find_packages(),
     setup_requires=['katversion'],
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     install_requires=[
         'aiohttp',
         'async_timeout',


### PR DESCRIPTION
There aren't actually any 3.6-isms, but on Jenkins mypy complains when
checking in 3.5 mode because aiohttp now uses 3.6 features. It's not
strictly necessary to set a `python_requires` for this, but since there
is no testing on 3.5 it's easier to just force 3.6 given that 3.5 is EOL
anyway.