### PR TITLE
Add support for SSH key auth

### DIFF
--- a/src/switch_exporter/server.py
+++ b/src/switch_exporter/server.py
@@ -49,7 +49,8 @@ def make_app(args: argparse.Namespace) -> web.Application:
         Switch,
         lldp_timeout=args.lldp_timeout,
         username=args.username,
-        password=args.password)
+        password=args.password,
+        keyfile=args.keyfile)
     app['cache'] = Cache(factory, args.connection_timeout)
     app['scrape_timeout'] = args.scrape_timeout
     app.router.add_get('/metrics', get_metrics)

--- a/src/switch_exporter/server.py
+++ b/src/switch_exporter/server.py
@@ -65,6 +65,9 @@ def get_arguments() -> argparse.Namespace:
         '--password', default='monitor',
         help='Password on switches')
     parser.add_argument(
+        '--keyfile',
+        help='SSH key for switches')
+    parser.add_argument(
         '--connection-timeout', type=float, default=120.0, metavar='SECONDS',
         help='Time to cache open SSH connections [%(default)s]')
     parser.add_argument(

--- a/src/switch_exporter/server.py
+++ b/src/switch_exporter/server.py
@@ -66,7 +66,7 @@ def get_arguments() -> argparse.Namespace:
         '--password', default='monitor',
         help='Password on switches')
     parser.add_argument(
-        '--keyfile',
+        '--keyfile', default=None,
         help='SSH client key for switches')
     parser.add_argument(
         '--connection-timeout', type=float, default=120.0, metavar='SECONDS',

--- a/src/switch_exporter/server.py
+++ b/src/switch_exporter/server.py
@@ -66,7 +66,7 @@ def get_arguments() -> argparse.Namespace:
         '--password', default='monitor',
         help='Password on switches')
     parser.add_argument(
-        '--keyfile', default=None,
+        '--keyfile', default=(),
         help='SSH client key for switches')
     parser.add_argument(
         '--connection-timeout', type=float, default=120.0, metavar='SECONDS',

--- a/src/switch_exporter/server.py
+++ b/src/switch_exporter/server.py
@@ -67,7 +67,7 @@ def get_arguments() -> argparse.Namespace:
         help='Password on switches')
     parser.add_argument(
         '--keyfile',
-        help='SSH key for switches')
+        help='SSH client key for switches')
     parser.add_argument(
         '--connection-timeout', type=float, default=120.0, metavar='SECONDS',
         help='Time to cache open SSH connections [%(default)s]')

--- a/src/switch_exporter/switch.py
+++ b/src/switch_exporter/switch.py
@@ -70,7 +70,7 @@ class Switch(Item):
         self.conn = await asyncssh.connect(
             self.hostname, known_hosts=None,
             username=self.username, password=self.password,
-            client_keys=self.keyfile, signature_algs=['rsa-sha2-512'])
+            client_keys=self.keyfile)
         result = await self._run_command('show interfaces ethernet status')
         self.ports = []
         for line in result.splitlines():

--- a/src/switch_exporter/switch.py
+++ b/src/switch_exporter/switch.py
@@ -43,6 +43,7 @@ class Switch(Item):
         self.hostname = hostname
         self.username = username
         self.password = password
+        self.keyfile = []
         self.lldp_info = {}           # type: Dict[str, LLDPRemoteInfo]
         self.lldp_time = 0.0          # time when LLDP info was last updated
         self.lldp_timeout = lldp_timeout
@@ -68,7 +69,8 @@ class Switch(Item):
     async def _connect_unlocked(self) -> None:
         self.conn = await asyncssh.connect(
             self.hostname, known_hosts=None,
-            username=self.username, password=self.password)
+            username=self.username, password=self.password,
+            client_keys=self.keyfile, signature_algs=['rsa-sha2-512'])
         result = await self._run_command('show interfaces ethernet status')
         self.ports = []
         for line in result.splitlines():

--- a/src/switch_exporter/switch.py
+++ b/src/switch_exporter/switch.py
@@ -35,15 +35,15 @@ class Switch(Item):
     does not automatically reconnect: if you get a connection error, throw
     it away (via :meth:`destroy`) and create a new one.
     """
-    def __init__(self, cache: Cache, hostname: str,
-                 username: str, password: str, lldp_timeout: float) -> None:
+    def __init__(self, cache: Cache, hostname: str, username: str,
+                 password: str, keyfile: str, lldp_timeout: float) -> None:
         super().__init__(cache, hostname)
         self.conn = None
         self.ports = []               # type: List[str]
         self.hostname = hostname
         self.username = username
         self.password = password
-        self.keyfile = []
+        self.keyfile = keyfile
         self.lldp_info = {}           # type: Dict[str, LLDPRemoteInfo]
         self.lldp_time = 0.0          # time when LLDP info was last updated
         self.lldp_timeout = lldp_timeout


### PR DESCRIPTION
To resolve #11 I wrote a PR. This shouldn't break existing deployments using password protection, and should auto search for keyfiles if none are specified.

I had to add `signature_algs=['rsa-sha2-512']` to get this working for my switch. Unsure if this is a Mellanox quirk or not.