### PR TITLE
Bump cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ async-timeout
 asyncssh==2.17.0
 attrs
 cffi==1.17.1              # via cryptography
-cryptography==46.0.5      # via asyncssh
+cryptography==46.0.7      # via asyncssh
 prometheus-client==0.21.1
 pycparser==2.22           # via cffi
 typing-extensions==4.13.2 # via cryptography - to override base-requirements.txt above


### PR DESCRIPTION
To keep dependabot happy (CVE-2026-39892); the issue is unlikely to actually affect us.