### PR TITLE
Add params for scrape targets

### DIFF
--- a/src/switch_exporter/server.py
+++ b/src/switch_exporter/server.py
@@ -21,12 +21,18 @@ async def get_metrics(request: web.Request) -> web.Response:
         target = request.query['target']
     except KeyError:
         raise web.HTTPBadRequest(text='target parameter omitted')
+
+    collect = request.query.getall('collect', None)
     cache = request.app['cache']
     switch = cache.get(target)
     timeout = request.app['scrape_timeout']
     try:
+        timeout = int(request.query.get('scrape_timeout', timeout))
+    except ValueError:
+        raise web.HTTPBadRequest(text='scrape_timeout must be an integer')
+    try:
         with switch:
-            counters = await switch.scrape(timeout)
+            counters = await switch.scrape(timeout, collect)
     except asyncio.CancelledError:
         raise
     except asyncio.TimeoutError:

--- a/src/switch_exporter/server.py
+++ b/src/switch_exporter/server.py
@@ -14,6 +14,7 @@ from .cache import Cache
 
 #: Time to keep SSH connections open
 CONNECTION_TIMEOUT = 120
+logger = logging.getLogger(__name__)
 
 
 async def get_metrics(request: web.Request) -> web.Response:
@@ -29,21 +30,26 @@ async def get_metrics(request: web.Request) -> web.Response:
     try:
         timeout = int(request.query.get('scrape_timeout', timeout))
     except ValueError:
-        raise web.HTTPBadRequest(text='scrape_timeout must be an integer')
+        logger.exception('Invalid scrape_timeout value')
+        raise web.HTTPBadRequest(text='scrape_timeout must be an integer') from None
     try:
         with switch:
             counters = await switch.scrape(timeout, collect)
     except asyncio.CancelledError:
         raise
     except asyncio.TimeoutError:
+        logger.exception('Scrape timed out')
         raise web.HTTPGatewayTimeout(
-            text='Scrape timed out after {}s'.format(timeout))
+            text='Scrape timed out after {}s'.format(timeout)
+        ) from None
     except ValidationError as e:
+        logger.exception('Validation error during scrape')
         raise web.HTTPBadRequest(text=str(e)) from None
     except Exception as exc:
         # Possibly a failed connection, so reset it
+        logger.exception('Exception during scrape, resetting switch')
         switch.destroy()
-        raise web.HTTPInternalServerError(text='Scrape failed: ' + str(exc))
+        raise web.HTTPInternalServerError(text='Scrape failed: ' + str(exc)) from None
     else:
         content = prometheus_client.generate_latest(counters).decode()
         return web.Response(text=content)

--- a/src/switch_exporter/server.py
+++ b/src/switch_exporter/server.py
@@ -8,7 +8,7 @@ import katsdpservices
 from aiohttp import web
 import prometheus_client
 
-from .switch import Switch
+from .switch import Switch, ValidationError
 from .cache import Cache
 
 
@@ -38,6 +38,8 @@ async def get_metrics(request: web.Request) -> web.Response:
     except asyncio.TimeoutError:
         raise web.HTTPGatewayTimeout(
             text='Scrape timed out after {}s'.format(timeout))
+    except ValidationError as e:
+        raise web.HTTPBadRequest(text=str(e)) from None
     except Exception as exc:
         # Possibly a failed connection, so reset it
         switch.destroy()

--- a/src/switch_exporter/switch.py
+++ b/src/switch_exporter/switch.py
@@ -108,6 +108,13 @@ class Switch(Item):
         self.lldp_timeout = lldp_timeout
         self._lock = asyncio.Lock()   # Serialises port and lldp info
         self.enable_timing_metrics = enable_timing_metrics
+        self.collectors = {
+            'counters': self._scrape_counters,
+            'state': self._scrape_state,
+            'operational_changes': self._scrape_operational_changes,
+            'link_diagnostic_code': self._scrape_link_diagnostic_code,
+            'transceiver_power': self._scrape_transceiver_power,
+        }
 
     def __repr__(self) -> str:
         return 'Switch({!r})'.format(self.hostname)
@@ -367,14 +374,29 @@ class Switch(Item):
         if self.enable_timing_metrics:
             timing_gauge.labels(self.hostname, coroutine.__name__).set(duration)
 
-    async def scrape(self, timeout: float) -> prometheus_client.CollectorRegistry:
+    async def scrape(
+        self,
+        timeout: float,
+        collectors: Optional[list[str]]
+    ) -> prometheus_client.CollectorRegistry:
         """Obtain the metrics from the switch"""
         start_time = time.perf_counter()
+        registry = prometheus_client.CollectorRegistry()
+        scrapers = []
+        if collectors is None:
+            for scraper in self.collectors.values():
+                scrapers.append(scraper(registry))
+        else:
+            for collector in collectors:
+                try:
+                    scrapers.append(self.collectors[collector](registry))
+                except KeyError:
+                    raise Exception(f'Unknown collector: {collector}')
+
         async with self._lock:
             await self._populate_ports()
             await self._update_lldp_periodically()
 
-        registry = prometheus_client.CollectorRegistry()
         timing_gauge = prometheus_client.Gauge(
             'switch_coroutine_duration_seconds', 'duration of the coroutine',
             labelnames=('hostname', 'coroutine'),
@@ -382,17 +404,12 @@ class Switch(Item):
         )
 
         # TODO: Use a TaskGroup instead of a list of tasks to robustly handle the async context.
-        scrapers = [
-            self._scrape_counters(registry),
-            self._scrape_state(registry),
-            self._scrape_operational_changes(registry),
-            self._scrape_link_diagnostic_code(registry),
-            self._scrape_transceiver_power(registry),
-        ]
         tasks = [asyncio.create_task(self.timed(s, timing_gauge), name=s.__name__)
                  for s in scrapers]
-        timeout = timeout - (time.perf_counter() - start_time)
-        done, pending = await asyncio.wait(tasks, timeout=timeout)
+        scrape_timeout = timeout - (time.perf_counter() - start_time)
+        if scrape_timeout <= 0:
+            raise Exception('Timed out before scraping any metrics')
+        done, pending = await asyncio.wait(tasks, timeout=scrape_timeout)
         exceptions = []
         for task in pending:
             logger.error('[%s] Cancelling scraping metrics: %s after %s seconds',

--- a/src/switch_exporter/switch.py
+++ b/src/switch_exporter/switch.py
@@ -43,6 +43,10 @@ _TRANSCEIVER_POWER_LOW_TX_THRESHOLD_RE = re.compile(
 _TRANSCEIVER_POWER_SECTION_RE = re.compile(r'Port (\d+\/\d+) transceiver diagnostic data:')
 
 
+class ValidationError(Exception):
+    pass
+
+
 @attr.s(slots=True)
 class LLDPRemoteInfo:
     name = attr.ib(type=str, default='')
@@ -251,18 +255,12 @@ class Switch(Item):
         )
 
         # Include the port header lines so we can associate each result with its port.
-        cmd = (
-            r'show interfaces ethernet '
-            r'| include "^Eth|^\s+Last change in operational status: |^"'
-        )
-        result = await self._run_command(cmd)
-        for port, section in split_aggregate(result, _PORT_RE, len(self.ports)):
-            info = self.lldp_info.get(port, LLDPRemoteInfo())
-            labels = (port, info.name, info.port_id, info.port_description)
+        cmd = (raise Exception(f'Unknown collector: {collector}')oteInfo())
+         labels = (port, info.name, info.port_id, info.port_description)
 
-            # Find the single operational status change line in this section.
-            count = 0
-            for line in section.splitlines():
+          # Find the single operational status change line in this section.
+          count = 0
+           for line in section.splitlines():
                 line = line.strip()
                 match = _OPERATIONAL_CHANGES_RE.match(line)
                 if match:
@@ -390,8 +388,8 @@ class Switch(Item):
             for collector in collectors:
                 try:
                     scrapers.append(self.collectors[collector](registry))
-                except KeyError:
-                    raise Exception(f'Unknown collector: {collector}')
+                except KeyError as e:
+                    raise ValidationError(f'Unknown collector: {collector}') from e
 
         async with self._lock:
             await self._populate_ports()
@@ -408,7 +406,7 @@ class Switch(Item):
                  for s in scrapers]
         scrape_timeout = timeout - (time.perf_counter() - start_time)
         if scrape_timeout <= 0:
-            raise Exception('Timed out before scraping any metrics')
+            raise asyncio.TimeoutError('Timed out before scraping any metrics')
         done, pending = await asyncio.wait(tasks, timeout=scrape_timeout)
         exceptions = []
         for task in pending:

--- a/src/switch_exporter/switch.py
+++ b/src/switch_exporter/switch.py
@@ -255,12 +255,18 @@ class Switch(Item):
         )
 
         # Include the port header lines so we can associate each result with its port.
-        cmd = (raise Exception(f'Unknown collector: {collector}')oteInfo())
-         labels = (port, info.name, info.port_id, info.port_description)
+        cmd = (
+            r'show interfaces ethernet '
+            r'| include "^Eth|^\s+Last change in operational status: |^"'
+        )
+        result = await self._run_command(cmd)
+        for port, section in split_aggregate(result, _PORT_RE, len(self.ports)):
+            info = self.lldp_info.get(port, LLDPRemoteInfo())
+            labels = (port, info.name, info.port_id, info.port_description)
 
-          # Find the single operational status change line in this section.
-          count = 0
-           for line in section.splitlines():
+            # Find the single operational status change line in this section.
+            count = 0
+            for line in section.splitlines():
                 line = line.strip()
                 match = _OPERATIONAL_CHANGES_RE.match(line)
                 if match:

--- a/src/switch_exporter/switch.py
+++ b/src/switch_exporter/switch.py
@@ -2,7 +2,7 @@ import logging
 import asyncio
 import re
 import time
-from typing import Any, Coroutine, Iterable, Optional, Pattern, Tuple
+from typing import Any, Coroutine, Iterable, List, Optional, Pattern, Tuple
 from typing_extensions import override
 
 import attr
@@ -377,7 +377,7 @@ class Switch(Item):
     async def scrape(
         self,
         timeout: float,
-        collectors: Optional[list[str]]
+        collectors: Optional[List[str]]
     ) -> prometheus_client.CollectorRegistry:
         """Obtain the metrics from the switch"""
         start_time = time.perf_counter()


### PR DESCRIPTION
Add params to specify which collectors to run when scraping, and specify the timeout for those requests.

This is in order to apply separate timeouts and scraper periods for `operational_changes` compared to `counters` as it is overloading the cpus when requesting the operational state on some older switches.
<img width="3779" height="920" alt="Screenshot from 2026-05-29 09-50-15" src="https://github.com/user-attachments/assets/e9804464-0706-4c1d-b6fa-99f48994194a" />
