### PR TITLE
Sections start at zero now

### DIFF
--- a/src/switch_exporter/switch.py
+++ b/src/switch_exporter/switch.py
@@ -240,8 +240,8 @@ class Switch(Item):
             sections = section.split()
             info = self.lldp_info.get(port, dummy_info)
             labels = (port, info.name, info.port_id, info.port_description)
-            port_enabled.labels(*labels).set(int(sections[1] == 'Enabled'))
-            port_up.labels(*labels).set(int(sections[2] == 'Up'))
+            port_enabled.labels(*labels).set(int(sections[0] == 'Enabled'))
+            port_up.labels(*labels).set(int(sections[1] == 'Up'))
 
     async def _scrape_operational_changes(
         self,


### PR DESCRIPTION
When updating the mechanism to populate state with the split method the sections should have been shifted since the port is no longer in the list.

Before:
<img width="1837" height="1040" alt="Screenshot from 2026-06-08 13-44-51" src="https://github.com/user-attachments/assets/79c6518f-463e-481c-980b-8989b68ca2b8" />


After:
<img width="1837" height="1040" alt="Screenshot from 2026-06-08 13-46-06" src="https://github.com/user-attachments/assets/b50cd153-bfa1-40ab-83e1-4bdeb5a1d991" />