### PR TITLE
fix aiomonitor dependencies when building with docker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 requires-python = ">=3.6"
 dependencies = [
     "aiohttp",
+    "aiomonitor",
     "async_timeout",
     "asyncssh",
     "attrs",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -d https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
+aiomonitor==0.7.0
 aiohttp
 async-timeout
 asyncssh==2.17.0


### PR DESCRIPTION
The base-requirements still require the dependency listed